### PR TITLE
feat: add polling interval option and options flow.

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -20,11 +20,13 @@ from .const import (
     ATTR_COORDINATOR,
     CONF_ACCESS_TOKEN,
     CONF_REFRESH_TOKEN,
+    CONF_POLLING_INTERVAL,
+    CONF_VIN,
+    DEFAULT_POLLING_INTERVAL,
     DOMAIN,
     ISSUE_URL,
     SENSORS,
     BINARY_SENSORS,
-    UPDATE_INTERVAL,
     VERSION,
 )
 
@@ -101,16 +103,21 @@ class RivianDataUpdateCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
         self._hass = hass
         self._api = client
         self._entry = entry
-        self._vin = entry.data.get("vin")
+        self._vin = entry.data.get(CONF_VIN)
         self._access_token = entry.data.get(CONF_ACCESS_TOKEN)
         self._refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
         self._client_id = entry.data.get(CONF_CLIENT_ID)
         self._client_secret = entry.data.get(CONF_CLIENT_SECRET)
+
+        _LOGGER.info(
+            "Rivian API starting with polling interval %s",
+            entry.options.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)
+        )
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=timedelta(seconds=entry.options.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)),
         )
 
     async def _update_api_data(self):

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -30,16 +30,18 @@ DOMAIN = "rivian"
 VERSION = "0.0.1-alpha.2"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 COORDINATOR = "rivian_coordinator"
-UPDATE_INTERVAL = 5
+MIN_POLLING_INTERVAL = 5 # seconds, this may be too low
+DEFAULT_POLLING_INTERVAL = 660 # seconds
 
 # Attributes
 ATTR_COORDINATOR = "rivian_coordinator"
 
 # Config properties
 CONF_OTP = "otp"
-CONF_VIN = "vehicle_id"
+CONF_VIN = "vin"
 CONF_ACCESS_TOKEN = "access_token"
 CONF_REFRESH_TOKEN = "refresh_token"
+CONF_POLLING_INTERVAL = "polling_interval"
 
 SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "core/ota_status/cgm_ota_install_fast_charging": RivianSensorEntity(

--- a/custom_components/rivian/strings.json
+++ b/custom_components/rivian/strings.json
@@ -17,9 +17,20 @@
                     "client_id": "Client ID",
                     "client_secret": "Client Secret",
                     "otp": "Verification Code",
-                    "vehicle_id": "Vehicle Identification"
+                    "polling_interval": "API Polling Interval (seconds)",
+                    "vin": "Vehicle Identification"
                 },
                 "title": "Setup your Rivian Integration"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Rivian API Options",
+                "data": {
+                    "polling_interval": "API Polling Interval (seconds)"
+                }
             }
         }
     }

--- a/custom_components/rivian/translations/en.json
+++ b/custom_components/rivian/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "title": "Rivian (Unofficial)",
         "abort": {
             "already_configured": "Device is already configured"
         },
@@ -16,9 +17,20 @@
                     "client_id": "Client ID",
                     "client_secret": "Client Secret",
                     "otp": "Verification Code",
-                    "vehicle_id": "Vehicle Identification Number"
+                    "polling_interval": "API Polling Interval (seconds)",
+                    "vin": "Vehicle Identification"
                 },
                 "title": "Setup your Rivian Integration"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Rivian API Options",
+                "data": {
+                    "polling_interval": "API Polling Interval (seconds)"
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #8.

Modeled this off the HACS plugin for Tesla. Default polling interval is 11 minutes as is Tesla. I don't know if anyone knows the sleep internals of Rivians (they seem to be pretty braindead at the moment and vampire drain is very high). So I am guessing here. I certainly believe the old default of `5` is way too frequent.

As I'm new to HA I haven't figured out why the translations are not making their way into the "Configure"/Options menu. Perhaps you can help on that and merge. Thanks for your work on this plugin!

<img width="423" alt="Screen Shot 2022-08-20 at 1 06 37 PM" src="https://user-images.githubusercontent.com/1197375/185758626-fb2a0afa-8436-4479-a4e3-19b14dff8804.png">
<img width="315" alt="Screen Shot 2022-08-20 at 1 08 49 PM" src="https://user-images.githubusercontent.com/1197375/185758627-f19841bc-d00a-4bc0-b044-5c8a1904fba5.png">

