### PR TITLE
Pin to alpha version of rivian-python-client

### DIFF
--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/bretterer/home-assistant-rivian",
     "requirements": [
-        "rivian-python-client==0.0.1-alpha.5"
+        "rivian-python-client==0.0.1a5"
     ],
     "codeowners": [
         "@bretterer"

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/bretterer/home-assistant-rivian",
     "requirements": [
-        "rivian-python-client>=0.1.0"
+        "rivian-python-client==0.0.1-alpha.5"
     ],
     "codeowners": [
         "@bretterer"


### PR DESCRIPTION
Pins the rivian-python-client to https://pypi.org/project/rivian-python-client/0.0.1a5/ which was working prior to the refactors that broke the 0.1.x releases.