### PR TITLE
Additional Missing Sensors Post GraphQL Conversion

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -178,6 +178,12 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             key=f"{DOMAIN}_telematics_ota_status_status_current",
         )
     ),
+    "otaCurrentVersion": RivianSensorEntity(
+        entity_description=RivianSensorEntityDescription(
+            name="Software OTA - Current Version",
+            key=f"{DOMAIN}_telematics_ota_status_current_version",
+        )
+    ),
     "otaCurrentVersionNumber": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version Number",
@@ -356,12 +362,6 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     #     entity_description=RivianSensorEntityDescription(
     #         name="Software OTA - Available Version",
     #         key=f"{DOMAIN}_telematics_ota_status_available_version",
-    #     )
-    # ),
-    # "telematics/ota_status/current_version": RivianSensorEntity(
-    #     entity_description=RivianSensorEntityDescription(
-    #         name="Software OTA - Current Version",
-    #         key=f"{DOMAIN}_telematics_ota_status_current_version",
     #     )
     # ),
     # "telematics/ota_status/pending_reason_active_mode": RivianSensorEntity(

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -478,6 +478,14 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
             on_value="open",
         )
     ),
+    "closureLiftgateLocked": RivianBinarySensorEntity(
+        entity_description=RivianBinarySensorEntityDescription(
+            name="Liftgate",
+            key=f"{DOMAIN}_body_closures_liftgate_locked_state",
+            device_class=BinarySensorDeviceClass.LOCK,
+            on_value="unlocked",
+        )
+    ),
     "closureSideBinLeftClosed": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Gear Tunnel Left",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -154,6 +154,12 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             key=f"{DOMAIN}_gearGuardVideoTermsAccepted",
         ),
     ),
+    "otaAvailableVersion": RivianSensorEntity(
+        entity_description=RivianSensorEntityDescription(
+            name="Software OTA - Available Version",
+            key=f"{DOMAIN}_telematics_ota_status_available_version",
+        )
+    ),
     "otaAvailableVersionNumber": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version Number",
@@ -357,12 +363,6 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     #         key=f"{DOMAIN}_energy_storage_vehicle_efficiency_lifetime_wh_per_km",
     #     ),
     #     value_lambda=lambda v: round(DistanceConverter.convert(v, UnitOfLength.MILES, UnitOfLength.KILOMETERS), 1),
-    # ),
-    # "telematics/ota_status/available_version": RivianSensorEntity(
-    #     entity_description=RivianSensorEntityDescription(
-    #         name="Software OTA - Available Version",
-    #         key=f"{DOMAIN}_telematics_ota_status_available_version",
-    #     )
     # ),
     # "telematics/ota_status/pending_reason_active_mode": RivianSensorEntity(
     #     entity_description=RivianSensorEntityDescription(


### PR DESCRIPTION
Additional found and mapped sensors include:
- liftgate locked status
- ota current version
- ota available version
