### PR TITLE
rework graphql reauthentication (only csrf needed)

### DIFF
--- a/custom_components/rivian/config_flow.py
+++ b/custom_components/rivian/config_flow.py
@@ -90,6 +90,7 @@ class RivianFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._access_token = None
         self._refresh_token = None
         self._session_token = None
+        self._user_session_token = None
 
     async def async_step_user(self, user_input=None):
         """Handle the flow"""

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -35,8 +35,6 @@ ATTR_COORDINATOR = "rivian_coordinator"
 # Config properties
 CONF_OTP = "otp"
 CONF_VIN = "vin"
-CONF_ACCESS_TOKEN = "access_token"
-CONF_REFRESH_TOKEN = "refresh_token"
 
 SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "batteryHvThermalEvent": RivianSensorEntity(
@@ -81,7 +79,9 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             native_unit_of_measurement=TEMP_FAHRENHEIT,
         ),
         value_lambda=lambda v: round(
-            TemperatureConverter.convert(v, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT),
+            TemperatureConverter.convert(
+                v, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            ),
             1,
         ),
     ),
@@ -93,7 +93,9 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             native_unit_of_measurement=TEMP_FAHRENHEIT,
         ),
         value_lambda=lambda v: round(
-            TemperatureConverter.convert(v, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT),
+            TemperatureConverter.convert(
+                v, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            ),
             1,
         ),
     ),
@@ -110,7 +112,9 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             key=f"{DOMAIN}_energy_storage_vehicle_energy_vehicle_range",
             native_unit_of_measurement=LENGTH_MILES,
         ),
-        value_lambda=lambda v: round(DistanceConverter.convert(v, UnitOfLength.KILOMETERS, UnitOfLength.MILES), 1),
+        value_lambda=lambda v: round(
+            DistanceConverter.convert(v, UnitOfLength.KILOMETERS, UnitOfLength.MILES), 1
+        ),
     ),
     "driveMode": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -313,7 +317,9 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             key=f"{DOMAIN}_dynamics_odometer_value",
             native_unit_of_measurement=LENGTH_MILES,
         ),
-        value_lambda=lambda v: round(DistanceConverter.convert(v, UnitOfLength.METERS, UnitOfLength.MILES), 1),
+        value_lambda=lambda v: round(
+            DistanceConverter.convert(v, UnitOfLength.METERS, UnitOfLength.MILES), 1
+        ),
     ),
     "windowFrontLeftCalibrated": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(


### PR DESCRIPTION
I've chosen to remove all the local state from `config_flow` it was never used once switching to graphql anyways (vehicle_state previously required a token, graphql client handles all authentication token exchange within the client code).

Should do similar to the other HA files... but that can be reserved for another time after the data sync and lockout issues are resolved.

Additionally with the existing python client implementation it is hard / impossible to parse graphql exceptions due to the exception handling swallowing the error details (response.body given everything is usually `response.status == 200` yay graphql 😡 I've always hated that FB decision).