### PR TITLE
validate_otp -> validate_otp_graphql and  persist all session tokens

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -23,6 +23,9 @@ from rivian.exceptions import RivianExpiredTokenError
 
 from .const import (
     ATTR_COORDINATOR,
+    CONF_ACCESS_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_USER_SESSION_TOKEN,
     CONF_VIN,
     DOMAIN,
     ISSUE_URL,
@@ -133,6 +136,12 @@ class RivianDataUpdateCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
         self._entry = entry
         self._vin = entry.data.get(CONF_VIN)
         self._login_attempts = 0
+
+        # sync tokens from initial configuration
+        self._api._access_token = entry.data.get(CONF_ACCESS_TOKEN)
+        self._api._refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
+        self._api._user_session_token = entry.data.get(CONF_USER_SESSION_TOKEN)
+
         super().__init__(
             hass,
             _LOGGER,
@@ -151,7 +160,7 @@ class RivianDataUpdateCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
 
         sensors.append("gnssLocation")
         try:
-            if self._login_attempts >= 4:
+            if self._login_attempts >= 5:
                 raise Exception("too many attempts to login - aborting")
 
             # determine if we need to authenticate and/or refresh csrf

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -35,6 +35,9 @@ ATTR_COORDINATOR = "rivian_coordinator"
 # Config properties
 CONF_OTP = "otp"
 CONF_VIN = "vin"
+CONF_ACCESS_TOKEN = "access_token"
+CONF_REFRESH_TOKEN = "refresh_token"
+CONF_USER_SESSION_TOKEN = "user_session_token"
 
 SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "batteryHvThermalEvent": RivianSensorEntity(

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/bretterer/home-assistant-rivian",
     "requirements": [
-        "rivian-python-client>=0.1.7"
+        "rivian-python-client>=0.1.8"
     ],
     "codeowners": [
         "@bretterer"


### PR DESCRIPTION
client modifications made in https://github.com/bretterer/rivian-python-client/pull/11 which were released in https://github.com/bretterer/rivian-python-client/releases/tag/0.1.8 allow for the logic in this PR to support/resolve https://github.com/bretterer/home-assistant-rivian/issues/35