### PR TITLE
Update various sensors (e.g., add icons, tweak friendly names, capitalize some states, etc.)

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -700,7 +700,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Front Left",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_left_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -709,7 +709,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Vented Seat Front Left",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_left_seat_vent_status",
-            device_class=BinarySensorDeviceClass.COLD,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -718,7 +718,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Front Right",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_right_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -727,7 +727,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Vented Seat Front Right",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_right_seat_vent_status",
-            device_class=BinarySensorDeviceClass.COLD,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -736,7 +736,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Rear Left",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_rear_left_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -745,7 +745,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Rear Right",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_rear_right_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -754,7 +754,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat 3rd Row Left",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_3rd_row_left_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -763,7 +763,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat 3rd Row Right",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_3rd_row_right_seat_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )
@@ -772,7 +772,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Steering Wheel",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_steering_wheel_heat_status",
-            device_class=BinarySensorDeviceClass.HEAT,
+            device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
             negate=True,
         )

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -174,7 +174,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Gear Guard Video Terms Accepted",
             icon="mdi:cctv",
             key=f"{DOMAIN}_gear_guard_video_terms_accepted",
-       ),
+        ),
         value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "otaAvailableVersion": RivianSensorEntity(
@@ -506,7 +506,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
         entity_description=RivianBinarySensorEntityDescription(
             name="Charger Connection",
             key=f"{DOMAIN}_energy_storage_charger_status_vehicle_charger_status",
-            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            device_class=BinarySensorDeviceClass.PLUG,
             on_value="chrgr_sts_not_connected",
             negate=True,
         )
@@ -610,6 +610,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "defrostDefogStatus": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Defrost/Defog",
+            icon="mdi:car-defrost-front",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_defrost_defog_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -699,6 +700,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatFrontLeftHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Front Left",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_left_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -708,6 +710,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatFrontLeftVent": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Vented Seat Front Left",
+            icon="mdi:car-seat-cooler",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_left_seat_vent_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -717,6 +720,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatFrontRightHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Front Right",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_right_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -726,6 +730,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatFrontRightVent": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Vented Seat Front Right",
+            icon="mdi:car-seat-cooler",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_right_seat_vent_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -735,6 +740,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatRearLeftHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Rear Left",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_rear_left_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -744,6 +750,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatRearRightHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat Rear Right",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_rear_right_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -753,6 +760,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatThirdRowLeftHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat 3rd Row Left",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_3rd_row_left_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -762,6 +770,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "seatThirdRowRightHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Seat 3rd Row Right",
+            icon="mdi:car-seat-heater",
             key=f"{DOMAIN}_thermal_hvac_mobile_status_3rd_row_right_seat_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",
@@ -771,6 +780,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "steeringWheelHeat": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Heated Steering Wheel",
+            icon="mdi:steering",  # ideally should be mdi:steering-heater, but that doesn't exist yet
             key=f"{DOMAIN}_thermal_hvac_mobile_status_steering_wheel_heat_status",
             device_class=BinarySensorDeviceClass.RUNNING,
             on_value="Off",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -854,6 +854,7 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "wiperFluidState": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Wiper Fluid Level",
+            icon="mdi:wiper-wash",
             key=f"{DOMAIN}_body_wipers_fluid_state",
             device_class=BinarySensorDeviceClass.PROBLEM,
             on_value="low",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -49,7 +49,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     ),
     "batteryHvThermalEventPropagation": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
-            name="Battery Thermal Runwaway Propagation",
+            name="Battery Thermal Runaway Propagation",
             icon="mdi:battery-alert",
             key=f"{DOMAIN}_energy_storage_icd_cid_notifications_b_pack_thermal_runaway_propagation",
         )
@@ -74,8 +74,8 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "brakeFluidLow": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Brake Fluid Level Low",
-            key=f"{DOMAIN}_dynamics/powertrain_status/brake_fluid_level_low",
             icon="mdi:car-brake-fluid-level",
+            key=f"{DOMAIN}_dynamics_powertrain_status_brake_fluid_level_low",
         ),
     ),
     "cabinClimateDriverTemperature": RivianSensorEntity(
@@ -109,9 +109,9 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "cabinPreconditioningType": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Cabin Climate Preconditioning Type",
-            key=f"{DOMAIN}_cabinPreconditioningType",
-        )
             icon="mdi:thermostat",
+            key=f"{DOMAIN}_cabin_preconditioning_type",
+        ),
     ),
     "distanceToEmpty": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -153,23 +153,23 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "gearGuardVideoMode": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Gear Guard Video Mode",
-            key=f"{DOMAIN}_gearGuardVideoMode",
             icon="mdi:cctv",
+            key=f"{DOMAIN}_gear_guard_video_mode",
         ),
     ),
     "gearGuardVideoStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Gear Guard Video Status",
-            key=f"{DOMAIN}_gearGuardVideoStatus",
             icon="mdi:cctv",
+            key=f"{DOMAIN}_gear_guard_video_status",
         ),
     ),
     "gearGuardVideoTermsAccepted": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
-            name="Gear Guard Video Status",
-            key=f"{DOMAIN}_gearGuardVideoTermsAccepted",
-        ),
+            name="Gear Guard Video Terms Accepted",
             icon="mdi:cctv",
+            key=f"{DOMAIN}_gear_guard_video_terms_accepted",
+       ),
     ),
     "otaAvailableVersion": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -314,7 +314,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "timeToEndOfCharge": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Charging Time Remaining",
-            key=f"{DOMAIN}_energy_storage_charger_EMS_charger_remainingtime_min_1",
+            key=f"{DOMAIN}_energy_storage_charger_EMS_charger_remaining_time_min_1",
             device_class=SensorDeviceClass.DURATION,
             native_unit_of_measurement=TIME_MINUTES,
         )

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -43,12 +43,14 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "batteryHvThermalEvent": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Battery Thermal Status",
+            icon="mdi:battery-alert",
             key=f"{DOMAIN}_dynamics_hv_battery_notifications_BMS_thermal_event",
         )
     ),
     "batteryHvThermalEventPropagation": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
-            name="Battery Thermal Runaway Propagation",
+            name="Battery Thermal Runwaway Propagation",
+            icon="mdi:battery-alert",
             key=f"{DOMAIN}_energy_storage_icd_cid_notifications_b_pack_thermal_runaway_propagation",
         )
     ),
@@ -64,6 +66,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "batteryLimit": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="SOC Limit",
+            icon="mdi:battery-charging-80",
             key=f"{DOMAIN}_energy_storage_mobile_soc_limit",
             native_unit_of_measurement=PERCENTAGE,
         )
@@ -72,6 +75,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
         entity_description=RivianSensorEntityDescription(
             name="Brake Fluid Level Low",
             key=f"{DOMAIN}_dynamics/powertrain_status/brake_fluid_level_low",
+            icon="mdi:car-brake-fluid-level",
         ),
     ),
     "cabinClimateDriverTemperature": RivianSensorEntity(
@@ -107,6 +111,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Cabin Climate Preconditioning Type",
             key=f"{DOMAIN}_cabinPreconditioningType",
         )
+            icon="mdi:thermostat",
     ),
     "distanceToEmpty": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -122,6 +127,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "driveMode": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Drive Mode",
+            icon="mdi:car-speed-limiter",
             key=f"{DOMAIN}_dynamics_modes_drive_mode",
         ),
         value_lambda=lambda v: {
@@ -140,6 +146,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "gearStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Gear Selector",
+            icon="mdi:car-shift-pattern",
             key=f"{DOMAIN}_dynamics_propulsion_status_prndl",
         ),
     ),
@@ -147,12 +154,14 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
         entity_description=RivianSensorEntityDescription(
             name="Gear Guard Video Mode",
             key=f"{DOMAIN}_gearGuardVideoMode",
+            icon="mdi:cctv",
         ),
     ),
     "gearGuardVideoStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Gear Guard Video Status",
             key=f"{DOMAIN}_gearGuardVideoStatus",
+            icon="mdi:cctv",
         ),
     ),
     "gearGuardVideoTermsAccepted": RivianSensorEntity(
@@ -160,124 +169,145 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Gear Guard Video Status",
             key=f"{DOMAIN}_gearGuardVideoTermsAccepted",
         ),
+            icon="mdi:cctv",
     ),
     "otaAvailableVersion": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_available_version",
         )
     ),
     "otaAvailableVersionNumber": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version Number",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_available_version_number",
         )
     ),
     "otaAvailableVersionWeek": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version Week",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_available_version_week",
         )
     ),
     "otaAvailableVersionYear": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version Year",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_available_version_year",
         )
     ),
     "otaCurrentStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Status Current",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_status_current",
         )
     ),
     "otaCurrentVersion": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_current_version",
         )
     ),
     "otaCurrentVersionNumber": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version Number",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_current_version_number",
         )
     ),
     "otaCurrentVersionWeek": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version Week",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_current_version_week",
         )
     ),
     "otaCurrentVersionYear": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version Year",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_current_version_year",
         )
     ),
     "otaDownloadProgress": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Download Progress",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_download_progress",
         )
     ),
     "otaInstallDuration": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Install Duration",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_install_duration",
         )
     ),
     "otaInstallProgress": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Install Progress",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_install_progress",
         )
     ),
     "otaInstallReady": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="CGM OTA Install - Install Ready",
+            icon="mdi:package",
             key=f"{DOMAIN}_core_ota_status_cgm_ota_install_ready",
         )
     ),
     "otaInstallTime": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Install Time",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_install_time",
         )
     ),
     "otaInstallType": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Install Type",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_install_type",
         )
     ),
     "otaStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Status",
+            icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_status",
         )
     ),
     "petModeTemperatureStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Pet Mode Temperature Status",
+            icon="mdi:dog-side",
             key=f"{DOMAIN}_thermal_hvac_settings_pet_mode_temperature_status",
         )
     ),
     "powerState": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Power State",
+            icon="mdi:power",
             key=f"{DOMAIN}_core_power_modes_power_state",
         )
     ),
     "rangeThreshold": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Range Threshold",
+            icon="mdi:map-marker-distance",
             key=f"{DOMAIN}_energy_storage_icd_cid_notifications_range_threshold",
         )
     ),
     "remoteChargingAvailable": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Remote Charging Available",
+            icon="mdi:battery-charging-wireless-80",
             key=f"{DOMAIN}_energy_storage_mobile_remote_charging_available",
         )
     ),
@@ -293,24 +323,28 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
         entity_description=RivianSensorEntityDescription(
             name="Tire Pressure Front Left",
             key=f"{DOMAIN}_dynamics_tires_tire_FL_pressure_status",
+            icon="mdi:tire",
         )
     ),
     "tirePressureStatusFrontRight": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Tire Pressure Front Right",
             key=f"{DOMAIN}_dynamics_tires_tire_FR_pressure_status",
+            icon="mdi:tire",
         )
     ),
     "tirePressureStatusRearLeft": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Tire Pressure Rear Left",
             key=f"{DOMAIN}_dynamics_tires_tire_RL_pressure_status",
+            icon="mdi:tire",
         )
     ),
     "tirePressureStatusRearRight": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Tire Pressure Rear Right",
             key=f"{DOMAIN}_dynamics_tires_tire_RR_pressure_status",
+            icon="mdi:tire",
         )
     ),
     "vehicleMileage": RivianSensorEntity(
@@ -328,24 +362,28 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
         entity_description=RivianSensorEntityDescription(
             name="Window Calibration Front Left State",
             key=f"{DOMAIN}_body_closures_window_calibration_FL_state",
+            icon="mdi:window-closed",
         )
     ),
     "windowFrontRightCalibrated": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Window Calibration Front Right State",
             key=f"{DOMAIN}_body_closures_window_calibration_FR_state",
+            icon="mdi:window-closed",
         )
     ),
     "windowRearLeftCalibrated": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Window Calibration Rear Left State",
             key=f"{DOMAIN}_body_closures_window_calibration_RL_state",
+            icon="mdi:window-closed",
         )
     ),
     "windowRearRightCalibrated": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Window Calibration Rear Right State",
             key=f"{DOMAIN}_body_closures_window_calibration_RR_state",
+            icon="mdi:window-closed",
         )
     ),
     # "core/ota_status/cgm_ota_install_fast_charging": RivianSensorEntity(
@@ -431,7 +469,6 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
     "alarmSoundStatus": RivianBinarySensorEntity(
         entity_description=RivianBinarySensorEntityDescription(
             name="Gear Guard Alarm",
-            icon="mdi:alarm",
             key=f"{DOMAIN}_body_alarm_sound_alarm",
             device_class=BinarySensorDeviceClass.TAMPER,
             on_value="true",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -45,7 +45,8 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Battery Thermal Status",
             icon="mdi:battery-alert",
             key=f"{DOMAIN}_dynamics_hv_battery_notifications_BMS_thermal_event",
-        )
+        ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "batteryHvThermalEventPropagation": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -112,6 +113,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             icon="mdi:thermostat",
             key=f"{DOMAIN}_cabin_preconditioning_type",
         ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "distanceToEmpty": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -149,6 +151,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             icon="mdi:car-shift-pattern",
             key=f"{DOMAIN}_dynamics_propulsion_status_prndl",
         ),
+        value_lambda=lambda v: v.title(),
     ),
     "gearGuardVideoMode": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -156,6 +159,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             icon="mdi:cctv",
             key=f"{DOMAIN}_gear_guard_video_mode",
         ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "gearGuardVideoStatus": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -163,6 +167,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             icon="mdi:cctv",
             key=f"{DOMAIN}_gear_guard_video_status",
         ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "gearGuardVideoTermsAccepted": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -170,6 +175,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             icon="mdi:cctv",
             key=f"{DOMAIN}_gear_guard_video_terms_accepted",
        ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "otaAvailableVersion": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -204,7 +210,8 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Software OTA - Status Current",
             icon="mdi:package",
             key=f"{DOMAIN}_telematics_ota_status_status_current",
-        )
+        ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "otaCurrentVersion": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -260,7 +267,8 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="CGM OTA Install - Install Ready",
             icon="mdi:package",
             key=f"{DOMAIN}_core_ota_status_cgm_ota_install_ready",
-        )
+        ),
+        value_lambda=lambda v: v.replace("_", " ").title().replace("Ota", "OTA"),
     ),
     "otaInstallTime": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
@@ -288,21 +296,24 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             name="Pet Mode Temperature Status",
             icon="mdi:dog-side",
             key=f"{DOMAIN}_thermal_hvac_settings_pet_mode_temperature_status",
-        )
+        ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "powerState": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Power State",
             icon="mdi:power",
             key=f"{DOMAIN}_core_power_modes_power_state",
-        )
+        ),
+        value_lambda=lambda v: v.title(),
     ),
     "rangeThreshold": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Range Threshold",
             icon="mdi:map-marker-distance",
             key=f"{DOMAIN}_energy_storage_icd_cid_notifications_range_threshold",
-        )
+        ),
+        value_lambda=lambda v: v.replace("_", " ").title(),
     ),
     "remoteChargingAvailable": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(

--- a/custom_components/rivian/sensor.py
+++ b/custom_components/rivian/sensor.py
@@ -107,7 +107,12 @@ class RivianSensor(RivianEntity, CoordinatorEntity, SensorEntity):
             entity = self.coordinator.data[self._prop_key]
             if entity is None:
                 return None
+            if self._sensor.value_lambda is None:
+                return {
+                    "last_update": entity["timeStamp"],
+                }
             return {
+                "native_value": entity["value"],
                 "last_update": entity["timeStamp"],
             }
         except KeyError:


### PR DESCRIPTION
Note that I have split this PR into multiple commits to make it easier to pick and choose which changes, if any, folks want to merge:

1. I have proposed icons for various sensors that did not already have them.  Please feel free to choose alternative icons, if others think there more appropriate options.  I also deleted the icon for the Gear Guard Alarm binary sensor.  The alarm clock did not seem like the most appropriate choice, and without a hardcoded icon, it will default to the customized on/off state-based icons for the `tamper` device class. 

2. I fixed a typo in the friendly name of Battery Thermal Runwaway Propagation sensor, and updated the friendly name of Gear Guard Video Terms Accepted to match the GraphQL name and avoid duplicating the name of the other Gear Guard Video Status sensor.  I also updated the key/entity_id for a few GraphQL sensors with underscores for consistency with HA entity_id convention.  Note this will orphan existing sensors and create new sensors in HA, requiring some clean up for existing users.

3. Various sensor values use inconsistent capitalization, space/underscore, etc.  I attempted to clean this up with some additional lambdas.

4. Previously, heated/ventilated seat binary sensors used HEAT/COLD device classes, which I thought were more intended to capture whether a given temperature sensor was above or below a threshold.  When off, the translated state shows as "Normal" in the UI, which looks odd.  I have proposed to change them to running device class, but I could also see removing the device class entirely and falling back to the standard "On/Off" binary sensor states. 