### PR TITLE
Require rivian-python-client version 0.1.9+

### DIFF
--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/bretterer/home-assistant-rivian",
     "requirements": [
-        "rivian-python-client>=0.1.8"
+        "rivian-python-client>=0.1.9"
     ],
     "codeowners": [
         "@bretterer"


### PR DESCRIPTION
Even after re-downloading the HACS component and restarting Home Assistant multiple times, the underlying client was not being updated to v0.1.9.  I made this change locally to force the update, but it probably makes sense to update the requirement.