### PR TITLE
HA deprecation: change to async_forward_entry_setups fixes issue #61

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -83,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         ATTR_MODEL: model,
     }
 
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
forward_entry_setups is deprecated and in a future HA version developers need to migrate to async version