### PR TITLE
fix commit icon mdi:source-commit not mdi:commit (older mdi naming)

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -241,7 +241,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "otaAvailableVersionGitHash": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Available Version Git Hash",
-            icon="mdi:commit",
+            icon="mdi:source-commit",
             key=f"{DOMAIN}_telematics_ota_status_available_version_git_hash",
         )
     ),
@@ -284,7 +284,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
     "otaCurrentVersionGitHash": RivianSensorEntity(
         entity_description=RivianSensorEntityDescription(
             name="Software OTA - Current Version Git Hash",
-            icon="mdi:commit",
+            icon="mdi:source-commit",
             key=f"{DOMAIN}_telematics_ota_status_current_version_git_hash",
         )
     ),


### PR DESCRIPTION
<img width="571" alt="image" src="https://user-images.githubusercontent.com/2158627/224077619-4b525435-770d-49cf-9e9c-647c87a8fbc0.png">

opps