### PR TITLE
fix off_road_auto mapping

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -174,7 +174,7 @@ SENSORS: Final[dict[str, RivianSensorEntity]] = {
             "distance": "Conserve",
             "winter": "Snow",
             "towing": "Towing",
-            "off_road_towing": "All-Terrain",
+            "off_road_auto": "All-Terrain",
             "off_road_sand": "Soft Sand",
             "off_road_rocks": "Rock Crawl",
             "off_road_sport_auto": "Rally",


### PR DESCRIPTION
Had the following error:

ValueError: Sensor sensor.rivian_dynamics_modes_drive_mode provides state value 'off_road_auto', which is not in the list of options provided

I guess Rivian had changed from off_road_towing->off_road_auto finally.