### PR TITLE
Fix wiper fluid state

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -988,7 +988,8 @@ BINARY_SENSORS: Final[dict[str, RivianBinarySensorEntity]] = {
             icon="mdi:wiper-wash",
             key=f"{DOMAIN}_body_wipers_fluid_state",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            on_value="low",
+            on_value="normal",
+            negate=True,
         )
     ),
 }


### PR DESCRIPTION
Adjusted the Wiper Fluid Level check to use `normal` as the "ok" value as my vehicle seems to be reporting `empty` instead of `low`. This will handle both scenarios.