### PR TITLE
Categorize all Software OTA sensors as diagnostic

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -289,6 +289,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaCurrentStatus",
             name="Software OTA - Status Current",
             icon="mdi:package",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_status_current",
             value_lambda=lambda v: v.replace("_", " ").title(),
         ),
@@ -342,6 +343,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaDownloadProgress",
             name="Software OTA - Download Progress",
             icon="mdi:progress-download",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_download_progress",
         ),
         RivianSensorEntityDescription(
@@ -349,6 +351,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaInstallDuration",
             name="Software OTA - Install Duration",
             icon="mdi:wrench-clock",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_install_duration",
         ),
         RivianSensorEntityDescription(
@@ -357,7 +360,6 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             name="Software OTA - Install Progress",
             icon="mdi:progress-clock",
             entity_category=EntityCategory.DIAGNOSTIC,
-            entity_registry_enabled_default=False,
             old_key=f"{DOMAIN}_telematics_ota_status_install_progress",
         ),
         RivianSensorEntityDescription(
@@ -365,6 +367,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaInstallReady",
             name="Software OTA - Install Ready",
             icon="mdi:progress-check",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_core_ota_status_cgm_ota_install_ready",
             value_lambda=lambda v: v.replace("_", " ").title().replace("Ota", "OTA"),
         ),
@@ -373,6 +376,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaInstallTime",
             name="Software OTA - Install Time",
             icon="mdi:clock",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_install_time",
         ),
         RivianSensorEntityDescription(
@@ -380,6 +384,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             field="otaInstallType",
             name="Software OTA - Install Type",
             icon="mdi:package",
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_install_type",
         ),
         RivianSensorEntityDescription(
@@ -400,6 +405,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
                 "Connection Lost",
                 "unavailable",
             ],
+            entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_telematics_ota_status_status",
             value_lambda=lambda v: v.replace("_", " ").title(),
         ),

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -360,6 +360,7 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             name="Software OTA - Install Progress",
             icon="mdi:progress-clock",
             entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
             old_key=f"{DOMAIN}_telematics_ota_status_install_progress",
         ),
         RivianSensorEntityDescription(


### PR DESCRIPTION
The `update` entity and the Software OTA `sensor` entities that are disabled by default are categorized as diagnostic, whereas the Software OTA `sensor` entities that are enabled by default are not.  For consistency, and in the interest of continuing to reduce the number and/or prominence of sensors that are mostly used for testing purposes, I am inclined to categorize the rest of the Software OTA `sensor` entities as diagnostic.

(Personally, I would disable all of them by default for new installations, and ultimately eliminate them in favor of the new `update` entity, but I recognize their value for testing purposes, and I'm sure there are folks who still use portions of the (excellent) @tmack8001 [dashboards](https://gist.github.com/tmack8001/d213097f4309a977d1806573cf2b2e91), which rely on the individual Software OTA `sensor` entities, so I will defer to others on whether and when to disable or deprecate them.)

That said, if the `Software OTA - Download Progress` entity is going to be enabled by default, I would also enable the `Software OTA - Install Progress` by default.  That change is also included in this PR.