### PR TITLE
fix on/off state for cabin preconditioning by removing negate logic

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -556,8 +556,7 @@ BINARY_SENSORS: Final[dict[str, tuple[RivianBinarySensorEntityDescription, ...]]
             name="Cabin Climate Preconditioning",
             old_key=f"{DOMAIN}_thermal_tmm_status_cabin_precondition_state",
             device_class=BinarySensorDeviceClass.RUNNING,
-            on_value=["undefined", "unavailable"],
-            negate=True,
+            on_value=["active"],
         ),
         RivianBinarySensorEntityDescription(
             key="charger_state",


### PR DESCRIPTION
This way we will correctly identify `complete_maintain` as off state for preconditioning.

![image](https://user-images.githubusercontent.com/2158627/234916344-2c179bfe-196f-4957-b675-f45f4fb4daf5.png)
