### PR TITLE
Adjust graphql subscription to use vehicle-id instead of vin

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     vehicle_coordinators: dict[str, VehicleCoordinator] = {}
     charging_coordinators: dict[str, ChargingCoordinator] = {}
     for vin in vehicles:
-        coor = VehicleCoordinator(hass=hass, client=client, vin=vin)
+        coor = VehicleCoordinator(hass=hass, client=client, vin=vehicles[vin]["id"])
         await coor.async_config_entry_first_refresh()
         vehicle_coordinators[vin] = coor
         coor = ChargingCoordinator(hass=hass, client=client, vin=vin)

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -141,7 +141,12 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
     @callback
     def _process_new_data(self, data: dict[str, Any]) -> None:
         """Process new data."""
-        vehicle_info = self._build_vehicle_info_dict(data["payload"]["data"][self.key])
+        if not (payload := data.get("payload")) or not (pdata := payload.get("data")):
+            _LOGGER.error("Received an unknown subscription update: %s", data)
+            self.update_interval = timedelta(seconds=15)
+            _LOGGER.warning("Reverting to polling every 15 seconds")
+            return
+        vehicle_info = self._build_vehicle_info_dict(pdata.get(self.key, {}))
         self.async_set_updated_data(vehicle_info)
         self.initial.set()
 


### PR DESCRIPTION
Additionally, fallback to using polling every 15 seconds if a subscription error happens