### PR TITLE
wallbox / wall charger charging_state can be reported as unavailable

### DIFF
--- a/custom_components/rivian/sensor.py
+++ b/custom_components/rivian/sensor.py
@@ -242,7 +242,7 @@ WALLBOX_SENSORS = (
         name="Charging status",
         icon="mdi:ev-plug-type1",
         device_class=SensorDeviceClass.ENUM,
-        options=["available", "disconnected", "plugged_in", "charging"],
+        options=["unavailable", "available", "disconnected", "plugged_in", "charging"],
         translation_key="charging_status",
     ),
     RivianWallboxSensorEntityDescription(

--- a/custom_components/rivian/strings.json
+++ b/custom_components/rivian/strings.json
@@ -25,6 +25,7 @@
     "sensor": {
       "charging_status": {
         "state": {
+          "unavailable": "Unavailable",
           "available": "Available",
           "disconnected": "[%key:common::state::disconnected%]",
           "plugged_in": "Plugged in",

--- a/custom_components/rivian/translations/en.json
+++ b/custom_components/rivian/translations/en.json
@@ -44,6 +44,7 @@
     "sensor": {
       "charging_status": {
         "state": {
+          "unavailable": "Unavailable",
           "available": "Available",
           "disconnected": "Disconnected",
           "plugged_in": "Plugged in",


### PR DESCRIPTION
```
File "/home/vscode/.local/lib/python3.11/site-packages/homeassistant/components/sensor/__init__.py", line 573, in state
    raise ValueError(
ValueError: Sensor sensor.wall_charger_charging_status provides state value 'unavailable', which is not in the list of options provided
```