### PR TITLE
Issue #122 backport fix from beta release - self.vin changed to self.vehicle_id for charging queries

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -76,9 +76,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coor.async_config_entry_first_refresh()
         vehicle_coordinators[vin] = coor
         
-        coor.charging_coordinator = ChargingCoordinator(hass=hass, client=client, vehicle_id=vehicle_id)
         await coor.charging_coordinator.async_config_entry_first_refresh()
-        charging_coordinators[vin] = coor
+        charging_coordinators[vin] = coor.charging_coordinator
 
     wallbox_coordinator = WallboxCoordinator(hass=hass, client=client)
     await wallbox_coordinator.async_config_entry_first_refresh()

--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -72,13 +72,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     charging_coordinators: dict[str, ChargingCoordinator] = {}
     for vin in vehicles:
         vehicle_id = vehicles[vin]["id"]
-        coor = VehicleCoordinator(
-            hass=hass, client=client, vehicle_id=vehicle_id
-        )
+        coor = VehicleCoordinator(hass=hass, client=client, vehicle_id=vehicle_id)
         await coor.async_config_entry_first_refresh()
         vehicle_coordinators[vin] = coor
-        coor = ChargingCoordinator(hass=hass, client=client, vehicle_id=vehicle_id)
-        await coor.async_config_entry_first_refresh()
+        
+        coor.charging_coordinator = ChargingCoordinator(hass=hass, client=client, vehicle_id=vehicle_id)
+        await coor.charging_coordinator.async_config_entry_first_refresh()
         charging_coordinators[vin] = coor
 
     wallbox_coordinator = WallboxCoordinator(hass=hass, client=client)

--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -71,12 +71,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     vehicle_coordinators: dict[str, VehicleCoordinator] = {}
     charging_coordinators: dict[str, ChargingCoordinator] = {}
     for vin in vehicles:
+        vehicle_id = vehicles[vin]["id"]
         coor = VehicleCoordinator(
-            hass=hass, client=client, vehicle_id=vehicles[vin]["id"]
+            hass=hass, client=client, vehicle_id=vehicle_id
         )
         await coor.async_config_entry_first_refresh()
         vehicle_coordinators[vin] = coor
-        coor = ChargingCoordinator(hass=hass, client=client, vin=vin)
+        coor = ChargingCoordinator(hass=hass, client=client, vehicle_id=vehicle_id)
         await coor.async_config_entry_first_refresh()
         charging_coordinators[vin] = coor
 

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -103,8 +103,8 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
     """Charging data update coordinator for Rivian."""
 
     key = "getLiveSessionData"
-    _unplugged_interval = 15 * 60 # 15 minutes
-    _plugged_interval = 30 # 30 seconds
+    _unplugged_interval = 15 * 60  # 15 minutes
+    _plugged_interval = 30  # 30 seconds
     _update_interval = _unplugged_interval  # 15 minutes
 
     def __init__(self, hass: HomeAssistant, client: Rivian, vehicle_id: str) -> None:
@@ -120,7 +120,9 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
 
     def adjust_update_interval(self, is_plugged_in: bool) -> None:
         """Adjust update interval based on plugged in status."""
-        self._set_update_interval(self._plugged_interval if is_plugged_in else self._unplugged_interval)
+        self._set_update_interval(
+            self._plugged_interval if is_plugged_in else self._unplugged_interval
+        )
 
 
 class UserCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
@@ -146,7 +148,6 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         super().__init__(hass=hass, client=client)
         self.vehicle_id = vehicle_id
         self.charging_coordinator = ChargingCoordinator(hass, client, vehicle_id)
-        self._awake = asyncio.Event()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Get the latest data from Rivian."""
@@ -201,16 +202,10 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         if items:
             _LOGGER.debug("Vehicle %s updated: %s", self.vehicle_id, redact(items))
 
-        if power_state := items.get("powerState"):
-            if power_state.get("value") == "sleep":
-                self._awake.clear()
-            else:
-                self._awake.set()
         if charger_status := items.get("chargerStatus"):
             self.charging_coordinator.adjust_update_interval(
                 is_plugged_in=charger_status.get("value") != "chrgr_sts_not_connected"
             )
-
 
         if not (prev_items := (self.data or {})):
             return items

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -28,6 +28,7 @@ from .const import (
     INVALID_SENSOR_STATES,
     VEHICLE_STATE_API_FIELDS,
 )
+from .helpers import redact
 
 _LOGGER = logging.getLogger(__name__)
 T = TypeVar("T", bound=dict[str, Any] | list[dict[str, Any]])

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -28,7 +28,6 @@ from .const import (
     INVALID_SENSOR_STATES,
     VEHICLE_STATE_API_FIELDS,
 )
-from .helpers import redact
 
 _LOGGER = logging.getLogger(__name__)
 T = TypeVar("T", bound=dict[str, Any] | list[dict[str, Any]])
@@ -201,7 +200,7 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         }
 
         if items:
-            _LOGGER.debug("Vehicle %s updated: %s", self.vehicle_id, redact(items))
+            _LOGGER.debug("Vehicle %s updated: %s", self.vehicle_id, items)
 
         if charger_status := items.get("chargerStatus"):
             self.charging_coordinator.adjust_update_interval(

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -103,17 +103,22 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
     """Charging data update coordinator for Rivian."""
 
     key = "getLiveSessionData"
+    _update_interval = 15 * 60  # 15 minutes
 
-    def __init__(self, hass: HomeAssistant, client: Rivian, vin: str) -> None:
+    def __init__(self, hass: HomeAssistant, client: Rivian, vehicle_id: str) -> None:
         """Initialize the coordinator."""
         super().__init__(hass=hass, client=client)
-        self.vin = vin
+        self.vehicle_id = vehicle_id
 
     async def _fetch_data(self) -> ClientResponse:
         """Fetch the data."""
         return await self.api.get_live_charging_session(
-            vin=self.vin, properties=CHARGING_API_FIELDS
+            vin=self.vehicle_id, properties=CHARGING_API_FIELDS
         )
+
+    def adjust_update_interval(self, is_plugged_in: bool) -> None:
+        """Adjust update interval based on plugged in status."""
+        self._set_update_interval(30 if is_plugged_in else self._update_interval)
 
 
 class UserCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -103,7 +103,9 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
     """Charging data update coordinator for Rivian."""
 
     key = "getLiveSessionData"
-    _update_interval = 15 * 60  # 15 minutes
+    _unplugged_interval = 15 * 60 # 15 minutes
+    _plugged_interval = 30 # 30 seconds
+    _update_interval = _unplugged_interval  # 15 minutes
 
     def __init__(self, hass: HomeAssistant, client: Rivian, vehicle_id: str) -> None:
         """Initialize the coordinator."""
@@ -118,7 +120,7 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
 
     def adjust_update_interval(self, is_plugged_in: bool) -> None:
         """Adjust update interval based on plugged in status."""
-        self._set_update_interval(30 if is_plugged_in else self._update_interval)
+        self._set_update_interval(self._plugged_interval if is_plugged_in else self._unplugged_interval)
 
 
 class UserCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):

--- a/custom_components/rivian/helpers.py
+++ b/custom_components/rivian/helpers.py
@@ -1,0 +1,33 @@
+"""Rivian helpers."""
+from __future__ import annotations
+
+from rivian import Rivian
+
+from homeassistant.components.diagnostics.util import _T, async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EMAIL, CONF_LATITUDE, CONF_LONGITUDE
+
+from .const import CONF_ACCESS_TOKEN, CONF_REFRESH_TOKEN, CONF_USER_SESSION_TOKEN
+
+TO_REDACT = {
+    CONF_EMAIL,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    "hrid",
+    "id",
+    "identityId",
+    "inviteId",
+    "mappedIdentityId",
+    "orderId",
+    "serialNumber",
+    "userId",
+    "vas",
+    "vehicleId",
+    "vin",
+    "wallboxId",
+}
+
+
+def redact(data: _T) -> dict:
+    """Redact sensitive data."""
+    return async_redact_data(data, TO_REDACT)


### PR DESCRIPTION
Also choosing to pull in the frequency change we have made based on if the vehicle is plugged in or not.

https://github.com/bretterer/home-assistant-rivian/issues/122 is resolved by switching the vehicle query over graphql from using `vehicle.vin` to using `vehicle.id`