### PR TITLE
add in new sensors from latest 2.x mobile releases

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -198,6 +198,12 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             value_lambda=lambda v: v.title(),
         ),
         RivianSensorEntityDescription(
+            key="trailer_status",
+            field="trailerStatus",
+            name="Trailer Status",
+            icon="mdi:truck-trailer",
+        ),
+        RivianSensorEntityDescription(
             key="gear_guard_video_mode",
             field="gearGuardVideoMode",
             name="Gear Guard Video Mode",
@@ -536,6 +542,20 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             icon="mdi:window-closed",
             entity_category=EntityCategory.DIAGNOSTIC,
             old_key=f"{DOMAIN}_body_closures_window_calibration_RR_state",
+        ),
+        RivianSensorEntityDescription(
+            key="windows_next_action",
+            field="windowsNextAction",
+            name="Windows Next Action",
+            icon="mdi:window-closed",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+        RivianSensorEntityDescription(
+            key="twelve_volt_battery_health",
+            field="twelveVoltBatteryHealth",
+            name="12V Battery Health",
+            icon="mdi:car-battery",
+            entity_category=EntityCategory.DIAGNOSTIC,
         ),
     ),
     "R1S": (
@@ -972,6 +992,7 @@ VEHICLE_STATE_API_FIELDS: Final[set[str]] = {
         for field in ([sensor.field] if isinstance(sensor.field, str) else sensor.field)
     ),
     "gnssLocation",
+    "gnssSpeed",
     "otaCurrentVersion",
     "otaCurrentVersionYear",
     "otaCurrentVersionWeek",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -894,6 +894,12 @@ BINARY_SENSORS: Final[dict[str, tuple[RivianBinarySensorEntityDescription, ...]]
             old_key=f"{DOMAIN}_use_state",
             on_value="go",
         ),
+        RivianBinarySensorEntityDescription(
+            key="car_wash_mode",
+            field="carWashMode",
+            name="Car Wash Mode",
+            icon="mdi:car-wash"
+        ),
     ),
     "R1T": (
         RivianBinarySensorEntityDescription(

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -120,6 +120,14 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             old_key=f"{DOMAIN}_energy_storage_mobile_soc_limit",
         ),
         RivianSensorEntityDescription(
+            key="bearing",
+            field="gnssBearing",
+            name="Bearing",
+            icon="mdi:compass",
+            native_unit_of_measurement=DEGREE,
+            suggested_display_precision=0,
+        ),
+        RivianSensorEntityDescription(
             key="brake_fluid_low",
             field="brakeFluidLow",
             name="Brake Fluid Level Low",

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -6,9 +6,11 @@ from typing import Final
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
+    DEGREE,
     PERCENTAGE,
     EntityCategory,
     UnitOfLength,
+    UnitOfSpeed,
     UnitOfTemperature,
     UnitOfTime,
 )

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -463,6 +463,15 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             old_key=f"{DOMAIN}_service_mode",
         ),
         RivianSensorEntityDescription(
+            key="speed",
+            field="gnssSpeed",
+            name="Speed",
+            device_class=SensorDeviceClass.SPEED,
+            native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=0,
+        ),
+        RivianSensorEntityDescription(
             key="time_to_end_of_charge",
             field="timeToEndOfCharge",
             name="Charging Time Remaining",
@@ -998,7 +1007,6 @@ VEHICLE_STATE_API_FIELDS: Final[set[str]] = {
         for field in ([sensor.field] if isinstance(sensor.field, str) else sensor.field)
     ),
     "gnssLocation",
-    "gnssSpeed",
     "otaCurrentVersion",
     "otaCurrentVersionYear",
     "otaCurrentVersionWeek",


### PR DESCRIPTION
Have this running locally, haven't see all the available enums for these sensors and like the 12v we likely won't see those until it reports unhealthy to someone so just wiring it straight through with the given value.