### PR TITLE
set binary_senor.on_value for car_wash_mode entity

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -915,7 +915,8 @@ BINARY_SENSORS: Final[dict[str, tuple[RivianBinarySensorEntityDescription, ...]]
             key="car_wash_mode",
             field="carWashMode",
             name="Car Wash Mode",
-            icon="mdi:car-wash"
+            icon="mdi:car-wash",
+            on_value="on",
         ),
     ),
     "R1T": (


### PR DESCRIPTION
I had this in my local setup, just never got pushed over to the PR... 🤦
<img width="546" alt="image" src="https://github.com/bretterer/home-assistant-rivian/assets/2158627/dcacc8b9-8f50-453e-9b02-02a67aa69970">
