### PR TITLE
Mark entities as unavailable if no data is present

### DIFF
--- a/custom_components/rivian/binary_sensor.py
+++ b/custom_components/rivian/binary_sensor.py
@@ -58,6 +58,16 @@ class RivianBinarySensorEntity(RivianVehicleEntity, BinarySensorEntity):
         self._aggregate = isinstance(self.entity_description.field, set)
 
     @property
+    def available(self) -> bool:
+        """Return the availability of the entity."""
+        if self._aggregate:
+            return self._available and any(
+                self._get_value(entity_key)
+                for entity_key in self.entity_description.field
+            )
+        return super().available
+
+    @property
     def is_on(self) -> bool:
         """Return true if sensor is on."""
         fields = self.entity_description.field

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -312,7 +312,7 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         new_data = prev_items | items
         for key in filter(lambda i: i != "gnssLocation", items):
             value = items[key].get("value")
-            if str(value).lower() in INVALID_SENSOR_STATES:
+            if str(value).lower() in INVALID_SENSOR_STATES and key in prev_items:
                 new_data[key] = prev_items[key]
             new_data[key]["history"] |= prev_items.get(key, {}).get("history", set())
 

--- a/custom_components/rivian/entity.py
+++ b/custom_components/rivian/entity.py
@@ -64,6 +64,9 @@ class RivianVehicleEntity(RivianEntity[VehicleCoordinator]):
     @property
     def available(self) -> bool:
         """Return the availability of the entity."""
+        if field := getattr(self.entity_description, "field", None):
+            if self._get_value(field) is None:
+                return False
         return self._available
 
     def _get_value(self, key: str) -> Any | None:


### PR DESCRIPTION
Prevents errors when integration is loading and data is missing, including when vehicle is in service mode