### PR TITLE
Set version to 0.0.0 in dev code (overwritten in releases)

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -22,7 +22,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "0.0.1-alpha.2"
+VERSION = "0.0.0"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/bretterer/home-assistant-rivian/issues",
   "loggers": ["custom_components.rivian", "rivian"],
   "requirements": ["rivian-python-client[ble]==1.1.1"],
-  "version": "0.6.0"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
Right now, if you look at https://analytics.home-assistant.io/custom_integrations.json, there are 2 instances installed with version 0.6.0 of the Rivian integration. While it is highly unlikely that those are actual installations from the 0.6.0 release, it is impossible to tell whether it is that or a copy from this integration code directly. This sets the version in the code to 0.0.0 (which is not a valid release) to better distinguish that scenario.