### PR TITLE
Replace _T TypeVar for compatibility with HA 2024.6

### DIFF
--- a/custom_components/rivian/helpers.py
+++ b/custom_components/rivian/helpers.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 from rivian import Rivian
 
-from homeassistant.components.diagnostics.util import _T, async_redact_data
+from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_LATITUDE, CONF_LONGITUDE
 
 from .const import CONF_ACCESS_TOKEN, CONF_REFRESH_TOKEN, CONF_USER_SESSION_TOKEN
+
+from typing import Any
 
 TO_REDACT = {
     CONF_EMAIL,
@@ -38,6 +40,6 @@ def get_rivian_api_from_entry(entry: ConfigEntry) -> Rivian:
     )
 
 
-def redact(data: _T) -> dict:
+def redact(data: Any) -> dict:
     """Redact sensitive data."""
     return async_redact_data(data, TO_REDACT)


### PR DESCRIPTION
Various TypeVars have been removed in core-2024.6b0, breaking the Rivian custom component. 

Defer to you all on how you want to handle the fix, but I substituted the `Any` type from the `typing` module locally to get the integration back up and running on my system, so I am throwing this out there for consideration.