### PR TITLE
Update Power State sensor enumerated values to include vehicle_reset

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -440,9 +440,10 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
                 "Ready",
                 "Sleep",
                 "Standby",
+                "Vehicle Reset",
             ],
             old_key="power_tate",  # to be removed 2024-06
-            value_lambda=lambda v: v.title(),
+            value_lambda=lambda v: v.replace("_", " ").title(),
         ),
         RivianSensorEntityDescription(
             key="range_threshold",


### PR DESCRIPTION
Update Power State sensor enumerated values to include recently observed value `vehicle_reset` as noted in Issue https://github.com/bretterer/home-assistant-rivian/issues/189