### PR TITLE
Add vehicle state last update time sensor

### DIFF
--- a/custom_components/rivian/binary_sensor.py
+++ b/custom_components/rivian/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -76,20 +75,3 @@ class RivianBinarySensorEntity(RivianVehicleEntity, BinarySensorEntity):
             result = val in values
             return result if not self.entity_description.negate else not result
         return STATE_UNAVAILABLE
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return the state attributes of the device."""
-        if self._aggregate:
-            return None
-        try:
-            entity = self.coordinator.data[self.entity_description.field]
-            if entity is None:
-                return "Binary Sensor Unavailable"
-            return {
-                "value": entity["value"],
-                "last_update": entity["timeStamp"],
-                "history": str(entity["history"]),
-            }
-        except KeyError:
-            return None

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -642,6 +642,15 @@ SENSORS: Final[dict[str, tuple[RivianSensorEntityDescription, ...]]] = {
             icon="mdi:bluetooth",
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
+        RivianSensorEntityDescription(
+            key="vehicle_state_last_update_time",
+            translation_key="vehicle_state_last_update_time",
+            field=None,
+            device_class=SensorDeviceClass.TIMESTAMP,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            value_fn=lambda coor: coor.last_update_time,
+        ),
     ),
     "R1S": (
         RivianSensorEntityDescription(
@@ -1033,7 +1042,12 @@ BINARY_SENSORS: Final[dict[str, tuple[RivianBinarySensorEntityDescription, ...]]
 }
 
 VEHICLE_STATE_API_FIELDS: Final[set[str]] = {
-    *(description.field for sensor in SENSORS.values() for description in sensor),
+    *(
+        description.field
+        for sensor in SENSORS.values()
+        for description in sensor
+        if description.field
+    ),
     *(
         field
         for sensors in BINARY_SENSORS.values()

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -250,6 +250,7 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
 
     key = "vehicleState"
     _update_interval_seconds = 15 * 60  # 15 minutes
+    _last_update_time: datetime | None = None
 
     def __init__(
         self,
@@ -270,6 +271,11 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         self._initial = asyncio.Event()
         self._unsub_handler: Coroutine[None, None, None] | None = None
         self._awake = asyncio.Event()
+
+    @property
+    def last_update_time(self) -> datetime | None:
+        """Return the last update time, if any."""
+        return self._last_update_time
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Get the latest data from Rivian."""
@@ -313,14 +319,13 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
 
     def _build_vehicle_info_dict(self, vijson: dict[str, Any]) -> dict[str, Any]:
         """Take the json output of vehicle_info and build a dictionary."""
-        items = {
-            k: v | ({"history": {v["value"]}} if "value" in v else {})
-            for k, v in vijson.items()
-            if v
-        }
+        items = {k: v for k, v in vijson.items() if v}
 
         if items:
             _LOGGER.debug("Vehicle %s updated: %s", self.vehicle_id, redact(items))
+            self._last_update_time = datetime.fromisoformat(
+                max(v["timeStamp"] for k, v in items.items())
+            )
 
         if power_state := items.get("powerState"):
             if power_state.get("value") == "sleep":
@@ -342,7 +347,6 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
             value = items[key].get("value")
             if str(value).lower() in INVALID_SENSOR_STATES and key in prev_items:
                 new_data[key] = prev_items[key]
-            new_data[key]["history"] |= prev_items.get(key, {}).get("history", set())
 
         return new_data
 

--- a/custom_components/rivian/device_tracker.py
+++ b/custom_components/rivian/device_tracker.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
@@ -26,14 +25,12 @@ async def async_setup_entry(
     vehicles: dict[str, Any] = data[ATTR_VEHICLE]
     coordinators: dict[str, VehicleCoordinator] = data[ATTR_COORDINATOR][ATTR_VEHICLE]
 
-    entities = [
+    async_add_entities(
         RivianDeviceEntity(
             coordinators[vehicle_id], entry, LOCATION_DESCRIPTION, vehicle
         )
         for vehicle_id, vehicle in vehicles.items()
-    ]
-
-    async_add_entities(entities)
+    )
 
 
 class RivianDeviceEntity(RivianVehicleEntity, TrackerEntity):
@@ -72,17 +69,6 @@ class RivianDeviceEntity(RivianVehicleEntity, TrackerEntity):
     def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
         return SourceType.GPS
-
-    # @property
-    # def location_accuracy(self) -> int:
-    #     return self._tracker_data[6]
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any]:
-        """Return the state attributes of the device."""
-        return {
-            "last_update": self._tracker_data["timeStamp"],
-        }
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/rivian/sensor.py
+++ b/custom_components/rivian/sensor.py
@@ -126,25 +126,6 @@ class RivianSensorEntity(RivianVehicleEntity, SensorEntity):
             self.options.append(rval)
         return rval
 
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return the state attributes of the device."""
-        try:
-            entity = self.coordinator.data[self.entity_description.field]
-            if entity is None:
-                return None
-            if self.entity_description.value_lambda is None:
-                return {
-                    "last_update": entity["timeStamp"],
-                }
-            return {
-                "native_value": entity["value"],
-                "last_update": entity["timeStamp"],
-                "history": str(entity["history"]),
-            }
-        except KeyError:
-            return None
-
 
 class RivianChargingSensorEntity(RivianChargingEntity, SensorEntity):
     """Representation of a Rivian charging sensor entity."""

--- a/custom_components/rivian/strings.json
+++ b/custom_components/rivian/strings.json
@@ -60,6 +60,9 @@
           "plugged_in": "Plugged in",
           "charging": "Charging"
         }
+      },
+      "vehicle_state_last_update_time": {
+        "name": "Vehicle state last update time"
       }
     }
   },

--- a/custom_components/rivian/translations/en.json
+++ b/custom_components/rivian/translations/en.json
@@ -59,6 +59,9 @@
           "plugged_in": "Plugged in",
           "charging": "Charging"
         }
+      },
+      "vehicle_state_last_update_time": {
+        "name": "Vehicle state last update time"
       }
     }
   },


### PR DESCRIPTION
## Potential breaking change
 - The `value`/`native_value`, `last_update` and `history` data points stored in `extra_state_attributes` have been removed. A single `Vehicle state last update time` sensor, which stores the most recent state update timestamp, has been created in case there is a need/desire to check for "staleness" of data. This sensor is disabled by default, so you will need to enable it if you want to use it.