### PR TITLE
feat: add charge current limit control

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -104,6 +104,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryNotReady("Issue loading vehicle data")
         await coor.charging_coordinator.async_config_entry_first_refresh()
         await coor.drivers_coordinator.async_config_entry_first_refresh()
+        await coor.charging_schedule_coordinator.async_config_entry_first_refresh()
         vehicle_coordinators[vehicle_id] = coor
 
     wallbox_coordinator = WallboxCoordinator(

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -141,6 +141,9 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         super().__init__(hass=hass, config_entry=config_entry, client=client)
         self.vehicle_id = vehicle_id
 
+    async def _async_update_data(self) -> dict:
+        return {}
+
     async def _fetch_data(self) -> ClientResponse:
         """Fetch the data."""
         return await self.api.get_live_charging_session(

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -299,6 +299,9 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         self.drivers_coordinator = DriverKeyCoordinator(
             hass=hass, config_entry=config_entry, client=client, vehicle_id=vehicle_id
         )
+        self.charging_schedule_coordinator = ChargingScheduleCoordinator(
+            hass=hass, config_entry=config_entry, client=client, vehicle_id=vehicle_id
+        )
         self._initial = asyncio.Event()
         self._unsub_handler: Coroutine[None, None, None] | None = None
         self._awake = asyncio.Event()

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -194,6 +194,35 @@ class DriverKeyCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         )
 
 
+class ChargingScheduleCoordinator(RivianDataUpdateCoordinator[list[dict[str, Any]]]):
+    """Charging schedule data update coordinator for Rivian."""
+
+    key = "getVehicle"
+    _update_interval_seconds = 30 * 60  # 30 minutes
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        client: Rivian,
+        vehicle_id: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(hass=hass, config_entry=config_entry, client=client)
+        self.vehicle_id = vehicle_id
+
+    async def _fetch_data(self) -> ClientResponse:
+        """Fetch charging schedule data."""
+        return await self.api.get_charging_schedules(self.vehicle_id)
+
+    async def _async_update_data(self) -> list[dict[str, Any]]:
+        """Get the latest charging schedule data."""
+        vehicle_data = await super()._async_update_data()
+        if isinstance(vehicle_data, dict):
+            return vehicle_data.get("chargingSchedules", [])
+        return []
+
+
 class UserCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
     """User data update coordinator for Rivian."""
 

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bretterer/home-assistant-rivian/issues",
   "loggers": ["custom_components.rivian", "rivian"],
-  "requirements": ["rivian-python-client[ble]==2.0.0"],
+  "requirements": ["rivian-python-client[ble] @ git+https://github.com/RAR/rivian-python-client.git@feat/charge-current-limit"],
   "version": "0.0.0"
 }

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bretterer/home-assistant-rivian/issues",
   "loggers": ["custom_components.rivian", "rivian"],
-  "requirements": ["rivian-python-client[ble] @ git+https://github.com/RAR/rivian-python-client.git@feat/charge-current-limit"],
+  "requirements": ["rivian-python-client[ble]==2.0.0"],
   "version": "0.0.0"
 }

--- a/custom_components/rivian/number.py
+++ b/custom_components/rivian/number.py
@@ -7,9 +7,13 @@ from typing import Any, Final
 
 from rivian import VehicleCommand
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -34,6 +38,10 @@ NUMBERS: Final[tuple[RivianNumberEntityDescription, ...]] = (
             command=VehicleCommand.CHARGING_LIMITS, params={"SOC_limit": int(value)}
         ),
     ),
+)
+
+CHARGE_CURRENT_LIMIT_DESCRIPTION = NumberEntityDescription(
+    key="charge_current_limit",
 )
 
 
@@ -67,3 +75,91 @@ class RivianNumberEntity(RivianVehicleControlEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.entity_description.set_fn(self.coordinator, value)
+
+
+_ALL_WEEKDAYS = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+class RivianChargingScheduleNumberEntity(RivianVehicleControlEntity, NumberEntity):
+    """Rivian charge current limit number entity backed by charging schedules."""
+
+    _attr_device_class = NumberDeviceClass.CURRENT
+    _attr_native_max_value = 48
+    _attr_native_min_value = 8
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+
+    entity_description: NumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: VehicleCoordinator,
+        config_entry: ConfigEntry,
+        vehicle: dict[str, Any],
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(
+            coordinator, config_entry, CHARGE_CURRENT_LIMIT_DESCRIPTION, vehicle
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.charging_schedule_coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if not super().available:
+            return False
+        schedules = self.coordinator.charging_schedule_coordinator.data
+        if schedules:
+            return True
+        return self._get_value("gnssLocation") is not None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the current charge current limit."""
+        schedules = self.coordinator.charging_schedule_coordinator.data
+        if schedules:
+            return schedules[0].get("amperage")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the charge current limit."""
+        schedule_coordinator = self.coordinator.charging_schedule_coordinator
+        schedules = schedule_coordinator.data or []
+
+        if schedules:
+            schedule = dict(schedules[0])
+            schedule["amperage"] = int(value)
+        else:
+            location = self._get_value("gnssLocation")
+            schedule = {
+                "weekDays": _ALL_WEEKDAYS,
+                "startTime": 0,
+                "duration": 1440,
+                "location": {
+                    "latitude": location["latitude"],
+                    "longitude": location["longitude"],
+                },
+                "amperage": int(value),
+                "enabled": True,
+            }
+
+        await self.coordinator.api.set_charging_schedules(
+            self.coordinator.vehicle_id, [schedule]
+        )
+        await schedule_coordinator.async_request_refresh()

--- a/custom_components/rivian/number.py
+++ b/custom_components/rivian/number.py
@@ -53,12 +53,21 @@ async def async_setup_entry(
     vehicles: dict[str, dict[str, Any]] = data[ATTR_VEHICLE]
     coordinators: dict[str, VehicleCoordinator] = data[ATTR_COORDINATOR][ATTR_VEHICLE]
 
-    entities = [
-        RivianNumberEntity(coordinators[vehicle_id], entry, description, vehicle)
-        for vehicle_id, vehicle in vehicles.items()
-        if vehicle.get("phone_identity_id")
-        for description in NUMBERS
-    ]
+    entities: list[NumberEntity] = []
+    for vehicle_id, vehicle in vehicles.items():
+        if not vehicle.get("phone_identity_id"):
+            continue
+        for description in NUMBERS:
+            entities.append(
+                RivianNumberEntity(
+                    coordinators[vehicle_id], entry, description, vehicle
+                )
+            )
+        entities.append(
+            RivianChargingScheduleNumberEntity(
+                coordinators[vehicle_id], entry, vehicle
+            )
+        )
     async_add_entities(entities)
 
 

--- a/custom_components/rivian/number.py
+++ b/custom_components/rivian/number.py
@@ -42,6 +42,7 @@ NUMBERS: Final[tuple[RivianNumberEntityDescription, ...]] = (
 
 CHARGE_CURRENT_LIMIT_DESCRIPTION = NumberEntityDescription(
     key="charge_current_limit",
+    name="Charge Current Limit",
 )
 
 
@@ -136,7 +137,7 @@ class RivianChargingScheduleNumberEntity(RivianVehicleControlEntity, NumberEntit
         schedules = self.coordinator.charging_schedule_coordinator.data
         if schedules:
             return True
-        return self._get_value("gnssLocation") is not None
+        return self.coordinator.data.get("gnssLocation") is not None
 
     @property
     def native_value(self) -> int | None:
@@ -155,7 +156,9 @@ class RivianChargingScheduleNumberEntity(RivianVehicleControlEntity, NumberEntit
             schedule = dict(schedules[0])
             schedule["amperage"] = int(value)
         else:
-            location = self._get_value("gnssLocation")
+            location = self.coordinator.data.get("gnssLocation")
+            if location is None:
+                return
             schedule = {
                 "weekDays": _ALL_WEEKDAYS,
                 "startTime": 0,


### PR DESCRIPTION
## Summary

Adds a new `number.<vehicle>_charge_current_limit` entity (8–48A) that controls the vehicle's charge amperage through the Rivian charging schedule API. This enables energy management systems like [evcc](https://evcc.io) to dynamically adjust charge current for solar surplus charging and load balancing.

Closes #153, closes #221, closes #244

### How it works

The Rivian API doesn't expose a standalone "set amperage" call. Instead, amperage is a field within a charging schedule, set via the `SetChargingSchedule` GraphQL mutation. This PR works around that by:

1. **Reading** the vehicle's current charging schedule via `getVehicle { chargingSchedules { ... } }`
2. **Modifying** only the `amperage` field
3. **Writing** the full schedule back via `setChargingSchedules`

If no schedule exists, a default 24/7 schedule is created at the vehicle's current GPS location when the user first sets a value.

### New components

**`ChargingScheduleCoordinator`** (`coordinator.py`)
- Polls `get_charging_schedules()` every 30 minutes (schedules change rarely)
- Created as a sub-coordinator on `VehicleCoordinator`, following the same pattern as `ChargingCoordinator` and `DriverKeyCoordinator`
- Also refreshed on-demand after every write so the entity reflects changes immediately

**`RivianChargingScheduleNumberEntity`** (`number.py`)
- Extends `RivianVehicleControlEntity` + `NumberEntity`
- Range: 8A min, 48A max, step 1A
- Reads amperage from the first schedule in the coordinator's data
- Subscribes to both the vehicle coordinator (for availability: park, zone, pairing) and the schedule coordinator (for state updates)
- Fallback schedule creation uses the vehicle's current `gnssLocation` from the vehicle coordinator

### Availability

The entity inherits standard vehicle control availability (gear in park, phone key paired, zone restrictions) and adds:
- **Available** if a charging schedule exists, OR if the vehicle has GPS data (enabling fallback creation)
- **Unavailable** if neither condition is met

### Dependencies

Requires [`get_charging_schedules()` and `set_charging_schedules()`](https://github.com/bretterer/rivian-python-client/pull/184) methods in `rivian-python-client` (PR pending).

## Test plan

- [x] Entity correctly reads amperage from existing charging schedule (verified: showed 48A)
- [x] Setting a value performs read-modify-write and updates the schedule (verified via Rivian app)
- [x] evcc can control charge current through the entity
- [x] Tested on 120V charger — amperage adjustment works, 8A minimum confirmed
- [x] Tested on 240V/48A charger — active charge rate adjusts correctly
- [x] Entity shows unavailable when vehicle is not in park
- [x] Fallback schedule creation works when no schedule exists (creates 24/7 all-week schedule at vehicle location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)