### PR TITLE
fix: gracefully handle deprecated getLiveSessionData API 

### DIFF
--- a/custom_components/rivian/__init__.py
+++ b/custom_components/rivian/__init__.py
@@ -102,7 +102,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coor.async_config_entry_first_refresh()
         if not coor.data:
             raise ConfigEntryNotReady("Issue loading vehicle data")
-        await coor.charging_coordinator.async_config_entry_first_refresh()
+        try:
+            await coor.charging_coordinator.async_config_entry_first_refresh()
+        except ConfigEntryNotReady:
+            _LOGGER.warning(
+                "Charging data unavailable for vehicle %s; "
+                "charging sensors will not update",
+                vehicle_id,
+            )
         await coor.drivers_coordinator.async_config_entry_first_refresh()
         vehicle_coordinators[vehicle_id] = coor
 

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -141,6 +141,23 @@ class ChargingCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
         super().__init__(hass=hass, config_entry=config_entry, client=client)
         self.vehicle_id = vehicle_id
 
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Get the latest charging data from Rivian.
+
+        Overrides the base class to gracefully handle the deprecated
+        getLiveSessionData API endpoint (renamed to getLiveSessionHistory
+        by Rivian). Until the upstream rivian-python-client library is
+        updated, we return cached/empty data instead of crashing.
+        """
+        try:
+            return await super()._async_update_data()
+        except UpdateFailed:
+            _LOGGER.warning(
+                "Charging data unavailable (getLiveSessionData API deprecated by Rivian). "
+                "Charging sensors will not update until the upstream library is fixed"
+            )
+            return self.data or {}
+
     async def _fetch_data(self) -> ClientResponse:
         """Fetch the data."""
         return await self.api.get_live_charging_session(


### PR DESCRIPTION
## Summary

Fixes #254 (and related #253)

Rivian removed the `getLiveSessionData` GraphQL query from their API, replacing it with `getLiveSessionHistory`. This causes the `rivian-python-client` library's `get_live_charging_session()` to return a `400 GRAPHQL_VALIDATION_FAILED`, which crashes the `ChargingCoordinator` and prevents the entire integration from loading.

## Changes

**`coordinator.py`**
- Override `_async_update_data` in `ChargingCoordinator` to catch `UpdateFailed` and return cached/empty data instead of propagating the error
- Logs a warning so users know charging sensors are inactive

**`__init__.py`**
- Wrap `charging_coordinator.async_config_entry_first_refresh()` in a try/except so a charging data failure during setup doesn't block the rest of the integration

## What this means for users

- The integration loads and works normally — vehicle state, locks, climate, location, etc. are all unaffected
- Charging sensors (cost, energy delivered, rate, etc.) will be inactive until `rivian-python-client` is updated upstream to use the new `getLiveSessionHistory` endpoint
- No more `Failed setup, will retry: Error communicating with API` errors
- No more log spam from repeated `RivianApiException` / `GRAPHQL_VALIDATION_FAILED`

## Notes

A simple rename of `getLiveSessionData` → `getLiveSessionHistory` in the coordinator key is not sufficient because the new endpoint returns a different data structure (as noted by @natekspencer in the 1.5.3b0 beta release). The proper long-term fix requires changes in `rivian-python-client` to handle the new response shape. This PR is the minimal safe fix to unblock users now.
