### PR TITLE
Avoid startup failure when gnssLocation is unavailable

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -1045,7 +1045,6 @@ VEHICLE_STATE_API_FIELDS: Final[set[str]] = {
         for sensor in sensors
         for field in ([sensor.field] if isinstance(sensor.field, str) else sensor.field)
     ),
-    "gnssLocation",
     "otaCurrentVersion",
     "otaCurrentVersionYear",
     "otaCurrentVersionWeek",

--- a/custom_components/rivian/device_tracker.py
+++ b/custom_components/rivian/device_tracker.py
@@ -31,6 +31,7 @@ async def async_setup_entry(
             coordinators[vehicle_id], entry, LOCATION_DESCRIPTION, vehicle
         )
         for vehicle_id, vehicle in vehicles.items()
+        if coordinators[vehicle_id].data.get("gnssLocation")
     ]
 
     async_add_entities(entities)
@@ -51,7 +52,7 @@ class RivianDeviceEntity(RivianVehicleEntity, TrackerEntity):
         """Create a Rivian device tracker entity."""
         super().__init__(coordinator, config_entry, description, vehicle)
         self._attribute = "gnssLocation"
-        self._tracker_data = coordinator.data[self._attribute]
+        self._tracker_data = coordinator.data.get(self._attribute, {})
 
     @property
     def force_update(self) -> bool:
@@ -61,12 +62,12 @@ class RivianDeviceEntity(RivianVehicleEntity, TrackerEntity):
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
-        return self._tracker_data["latitude"]
+        return self._tracker_data.get("latitude")
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
-        return self._tracker_data["longitude"]
+        return self._tracker_data.get("longitude")
 
     @property
     def source_type(self) -> SourceType:
@@ -81,15 +82,17 @@ class RivianDeviceEntity(RivianVehicleEntity, TrackerEntity):
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the state attributes of the device."""
         return {
-            "last_update": self._tracker_data["timeStamp"],
+            "last_update": self._tracker_data.get("timeStamp"),
         }
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Respond to a DataUpdateCoordinator update."""
-        entity = self.coordinator.data[self._attribute]
+        entity = self.coordinator.data.get(self._attribute)
+        if not entity:
+            return
         try:
-            if entity["timeStamp"] != self._tracker_data["timeStamp"]:
+            if entity["timeStamp"] != self._tracker_data.get("timeStamp"):
                 self._tracker_data = entity
                 self.async_write_ha_state()
         except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary

This avoids requesting `gnssLocation` as part of the vehicle state fields and makes the device tracker setup tolerate vehicles that do not have a `gnssLocation` payload.

## Why

While debugging a Home Assistant instance on 2026-06-20, the Rivian config entry was stuck in `setup_retry` and the battery sensor remained restored/stale. Direct GraphQL probes against the Rivian API showed:

- `batteryLevel` and `powerState` still return successfully.
- The full integration vehicle-state query fails with `GRAPHQL_VALIDATION_FAILED`.
- Isolating fields showed `gnssLocation { latitude longitude timeStamp isAuthorized }` is the failing field.
- Removing `gnssLocation` allowed the integration to load and the battery sensor to refresh normally.

I also checked `geoLocation` as a possible replacement. It validates only as a normal `{ timeStamp value }` field, and in this case returned the string `Unknown`, so it does not appear to be a drop-in replacement for the old device tracker payload.

## Behavior change

Vehicle state entities such as battery can load even when Rivian no longer exposes the old `gnssLocation` shape. The device tracker entity is skipped unless the coordinator actually has a `gnssLocation` payload.

## Validation

- `uv run --with ruff ruff check custom_components/rivian/const.py custom_components/rivian/device_tracker.py`
- `uv run --with ruff ruff format --check custom_components/rivian/const.py custom_components/rivian/device_tracker.py`
- `uv run python -m py_compile custom_components/rivian/const.py custom_components/rivian/device_tracker.py`
- Local Home Assistant custom-component hot patch with the same field removal loaded the Rivian entry and refreshed the battery sensor successfully.
