### PR TITLE
fix: don't fail setup after waiting only 1s for the first vehicle push

### DIFF
--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -37,6 +37,11 @@ from .helpers import redact
 _LOGGER = logging.getLogger(__name__)
 T = TypeVar("T", bound=dict[str, Any] | list[dict[str, Any]])
 
+# Maximum time to wait for the first vehicle state to arrive after subscribing.
+# The first `_process_new_data` callback has been observed ~27s after the
+# subscription is established, so this needs meaningful headroom.
+INITIAL_UPDATE_TIMEOUT = 60
+
 
 class RivianDataUpdateCoordinator(DataUpdateCoordinator[T], Generic[T], ABC):
     """Data update coordinator for the Rivian integration."""
@@ -282,9 +287,12 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
             )
 
             try:
-                await asyncio.wait_for(self._initial.wait(), 1)
+                await asyncio.wait_for(self._initial.wait(), INITIAL_UPDATE_TIMEOUT)
             except asyncio.TimeoutError as err:
-                raise UpdateFailed from err
+                raise UpdateFailed(
+                    "Timed out waiting for initial vehicle data after "
+                    f"{INITIAL_UPDATE_TIMEOUT}s"
+                ) from err
 
         return self.data
 


### PR DESCRIPTION
# fix: don't fail setup after waiting only 1s for the first vehicle push

Fixes #272

## Problem

`VehicleCoordinator._async_update_data` subscribes for vehicle updates and then waits **1 second**
for `self._initial` before raising `UpdateFailed`:

```python
try:
    await asyncio.wait_for(self._initial.wait(), 1)
except asyncio.TimeoutError as err:
    raise UpdateFailed from err
```

`self._initial` is only set in `_process_new_data`, and that first push does not arrive within 1s in
practice. I measured **27.1 seconds** between the subscription being established and the first
callback.

When it times out, `async_config_entry_first_refresh()` in `async_setup_entry` raises, the entry
lands in `setup_retry`, and no vehicle entities are created. Because the raise carries no message,
the entry's failure `reason` is `None` — neither the UI nor the websocket API gives any hint as to
why, and nothing is logged at default level. That combination made this quite hard to track down.

Measured on a config entry reload with debug logging enabled:

```
12:38:24.205 [rivian.rivian] <vehicle-id> subscribed to updates
12:38:51.338 [coordinator] Vehicle <vehicle-id> updated: {...}   <- _initial.set() happens here, +27.1s
12:38:51.339 [coordinator] Finished fetching rivian data in 36.172 seconds (success: True)
```

## Changes

1. **Add `INITIAL_UPDATE_TIMEOUT = 60`** and use it in place of the literal `1`. The measured
   latency was 27s, so 60s leaves real headroom without stalling setup indefinitely.
2. **Attach a message to `UpdateFailed`** so a genuine timeout surfaces a readable reason on the
   config entry instead of an empty `reason: None`.

## Note on a possible follow-up

On the `parallax-support` branch, `_process_parallax_data` delivers usable vehicle state
noticeably sooner than the full-state push — in the same capture above it applied
`{'powerState': 'ready'}` at `12:38:38.073`, about **13s before** `_process_new_data` fired — and it
already writes that data into `self.data` via `async_set_updated_data`. Setting `self._initial`
there as well would let setup complete as soon as any vehicle data lands.

That code doesn't exist on `main`, so it's deliberately not part of this PR. Happy to open a
follow-up against `parallax-support` if you'd like it.

## Testing

- Reproduced on `1.5.3b2` (+ the `parallax-support` build of `rivian-python-client`): entry stuck in
  `setup_retry` with `reason=None` and 0 entities.
- With this change, setup completes reliably and 121/129 entities populate (the remainder are
  charging-session fields that only populate while plugged in).
- Verified `self._initial` is otherwise only set in `_process_new_data` and cleared in
  `_unsubscribe`, so the timeout change doesn't affect any other control flow.
- `ruff check` reports no new findings. The file has one pre-existing `PYI059` error
  (`Generic[] should always be the last base class`) that is present on unmodified `main` and is
  untouched by this change. `ruff format --check` reports the file as already formatted.

## Environment used for testing

Home Assistant `2026.8.1` (Container install, Python 3.14), Rivian R1T (2023) with
`VEHICLE_CONNECTIVITY_PARALLAX` reported as `AVAILABLE`.
