### PR TITLE
fix: prevent vehicleMileage oscillation between Parallax and GraphQL …

### DIFF
--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -453,7 +453,9 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
                     # Parallax encodes odometer as integer km; GraphQL provides float meters.
                     # Both sources active causes oscillation that corrupts utility meters.
                     # Only accept Parallax value if >= stored (monotonic increase).
-                    prev_val = (self.data or {}).get("vehicleMileage", {}).get("value", 0)
+                    prev_val = (
+                        (self.data or {}).get("vehicleMileage", {}).get("value", 0)
+                    )
                     new_val = clean[k]
                     if isinstance(new_val, (int, float)) and new_val >= prev_val:
                         vehicle_updates[k] = {"value": new_val, "history": {new_val}}

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -449,6 +449,14 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
             for k in vehicle_keys:
                 if k == "gnssLocation":
                     vehicle_updates[k] = clean[k]
+                elif k == "vehicleMileage":
+                    # Parallax encodes odometer as integer km; GraphQL provides float meters.
+                    # Both sources active causes oscillation that corrupts utility meters.
+                    # Only accept Parallax value if >= stored (monotonic increase).
+                    prev_val = (self.data or {}).get("vehicleMileage", {}).get("value", 0)
+                    new_val = clean[k]
+                    if isinstance(new_val, (int, float)) and new_val >= prev_val:
+                        vehicle_updates[k] = {"value": new_val, "history": {new_val}}
                 else:
                     vehicle_updates[k] = {"value": clean[k], "history": {clean[k]}}
             new_data = (self.data or {}) | vehicle_updates


### PR DESCRIPTION
**Problem**

With both the GraphQL subscription and Parallax WebSocket active, `vehicleMileage` is written by two sources simultaneously:

- GraphQL (`vehicleMileage`): float meters, sub-meter precision
- Parallax (`dynamics.vehicle.odometer`): integer km × 1000, ~1 km resolution

While parked, the stored value oscillates every ~3 minutes between the two — differing by up to ~0.62 mi (~1 km). This is harmless for most sensors, but `vehicleMileage` has `state_class: total_increasing`. HA utility meters (e.g. a daily mileage helper) treat every upswing as real distance traveled, accumulating hundreds of fake miles per day while the vehicle sits in the driveway.

**Root cause**

`dynamics.vehicle.odometer` is the Parallax successor to the legacy `vehicleMileage` GraphQL field. During this migration period, both sources are active. The Parallax value is always ≤ the GraphQL value for the same physical position (integer km truncation vs. float meters), causing a persistent oscillation.

**Fix**

Enforce monotonic increase for `vehicleMileage` in `_process_parallax_data`. The Parallax value is only accepted if it is ≥ the currently stored value. When parked, Parallax updates are silently dropped. When driving and the vehicle crosses a km boundary, the Parallax value correctly exceeds the stored reading and is accepted.

**Testing**

Verified locally: `sensor.r1s_odometer` no longer oscillates while parked, and a daily mileage utility meter (`sensor.r1s_daily_mileage`) holds steady at the correct value.